### PR TITLE
Fix dependencies and make code compilable

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry excluding="ch/njol/skript/CommandHandler.java|ch/njol/skript/PlayerCommand.java|ch/njol/skript/ConfigCommandHandler.java|ch/njol/skript/expressions/ExprAttackerAlt.java|ch/njol/skript/effects/EffExec.java|ch/njol/skript/events/EvtServerStart.java|ch/njol/skript/config/ParseOptionNode.java|ch/njol/skript/effects/IndeterminateDelay.java|ch/njol/skript/bukkitutil/UnresolvedOfflinePlayer.java" including="**/*.java" kind="src" path="src/main/java"/>
-	<classpathentry including="**/*.java" kind="src" output="target/test-classes" path="src/test/java"/>
+	<classpathentry including="**/*.java" kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/.project
+++ b/.project
@@ -11,11 +11,6 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>edu.umd.cs.findbugs.plugin.eclipse.findbugsBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
@@ -24,6 +19,5 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
-		<nature>edu.umd.cs.findbugs.plugin.eclipse.findbugsNature</nature>
 	</natures>
 </projectDescription>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<version>2.2-Fixes-V9b</version>
 	<name>Skript</name>
 	<description>A plugin for the Minecraft server API Bukkit that allows to create scripts in natural language.</description>
-	<url>http://njol.ch/projects/skript/</url>
+	<url>https://github.com/Mirreski/Skript</url>
 	<licenses>
 		<license>
 			<name>GNU General Public License 3.0</name>
@@ -15,13 +15,13 @@
 	</licenses>
 	<inceptionYear>2011</inceptionYear>
 	<scm>
-		<developerConnection>scm:git:git://github.com/Njol/Skript.git</developerConnection>
-		<connection>scm:git:git://github.com/Njol/Skript.git</connection>
-		<url>http://github.com/Njol/Skript</url>
+		<developerConnection>scm:git:git://github.com/Mirreski/Skript.git</developerConnection>
+		<connection>scm:git:git://github.com/Mirreski/Skript.git</connection>
+		<url>http://github.com/Mirreski/Skript</url>
 	</scm>
 	<issueManagement>
 		<system>GitHub</system>
-		<url>http://github.com/Njol/Skript/issues</url>
+		<url>http://github.com/Mirreski/Skript/issues</url>
 	</issueManagement>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -31,13 +31,13 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.8.7-R0.1-SNAPSHOT</version>
+			<version>1.8.8-R0.1-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
-			<groupId>lib.PatPeter.SQLibrary</groupId>
-			<artifactId>SQLibrary</artifactId>
-			<version>7.1</version>
+			<groupId>patpeter</groupId>
+			<artifactId>sqlibrary</artifactId>
+			<version>4.0</version>
 		</dependency>
 
 		<dependency>
@@ -86,16 +86,16 @@
 	</dependencies>
 	<repositories>
 		<repository>
+			<id>techcable-repo</id>
+			<url>http://repo.techcable.net/content/repositories/public/</url>
+		</repository>
+		<repository>
 			<id>spigot-repo</id>
 			<url>http://hub.spigotmc.org/nexus/content/groups/public/</url>
 		</repository>
 		<repository>
-			<id>sqlibrary-repo</id>
-			<url>http://repo.dakanilabs.com/content/repositories/public/</url>
-		</repository>
-		<repository>
-			<id>vault-repo</id>
-			<url>http://nexus.theyeticave.net/content/repositories/pub_releases/</url>
+	    	<id>vault-repo</id>
+	    	<url>http://nexus.hc.to/content/repositories/pub_releases/</url>
 		</repository>
 		<repository>
 			<id>sk89q-repo</id>

--- a/src/main/java/ch/njol/skript/Skript.java
+++ b/src/main/java/ch/njol/skript/Skript.java
@@ -33,12 +33,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Scanner;
-import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.logging.Filter;
@@ -121,7 +118,6 @@ import ch.njol.skript.variables.Variables;
 import ch.njol.util.Closeable;
 import ch.njol.util.Kleenean;
 import ch.njol.util.NullableChecker;
-import ch.njol.util.Pair;
 import ch.njol.util.StringUtils;
 import ch.njol.util.coll.CollectionUtils;
 import ch.njol.util.coll.iterator.CheckedIterator;
@@ -514,6 +510,7 @@ public final class Skript extends JavaPlugin implements Listener {
 			@Override
 			public void run() {
 				String s = getMirreVersion();
+				if(s == null) return;
 				if(!s.equalsIgnoreCase(MIRRE)){
 					Bukkit.getLogger().info("[Skript] A new version of Skript Fixes has been found. Skript 2.2 Fixes " + s + " has been released. It's recommended to try the latest version.");
 				}
@@ -522,13 +519,15 @@ public final class Skript extends JavaPlugin implements Listener {
 		});
 	}
 	
+	@Nullable
 	static String getMirreVersion(){
 		try {
+		  //FIXME Update site seems to be down
 	      URL url = new URL("http://mirre.eu.pn/version/");
 	      Scanner scanner = new Scanner(url.openStream());
-	      String str = "";
+	      @Nullable String str = null;
 	      while (scanner.hasNext()) {
-	          str = str + scanner.next();
+	          str = str != null ? str + scanner.next() : scanner.next();
 	      }
 	      scanner.close();
 	      return str;
@@ -536,7 +535,7 @@ public final class Skript extends JavaPlugin implements Listener {
 	    catch (IOException ex) {
 	    	
 	    }
-	    return "";
+	    return null;
 	}
 	
 	private static Version minecraftVersion = new Version(666);

--- a/src/main/java/ch/njol/skript/aliases/ItemType.java
+++ b/src/main/java/ch/njol/skript/aliases/ItemType.java
@@ -468,6 +468,7 @@ public class ItemType implements Unit, Iterable<ItemData>, Container<ItemStack>,
 		enchs.put(e, level);
 	}
 	
+	@SuppressWarnings("null")
 	public void addEnchantments(final Map<Enchantment, Integer> enchantments) {
 		if (this.enchantments == null)
 			this.enchantments = new HashMap<Enchantment, Integer>(enchantments);

--- a/src/main/java/ch/njol/skript/classes/ClassInfo.java
+++ b/src/main/java/ch/njol/skript/classes/ClassInfo.java
@@ -114,6 +114,7 @@ public class ClassInfo<T> implements Debuggable {
 	 *            must be english and match singular and plural.
 	 * @throws PatternSyntaxException If any of the patterns' syntaxes is invalid
 	 */
+	@SuppressWarnings("null")
 	public ClassInfo<T> user(final String... userInputPatterns) throws PatternSyntaxException {
 		assert this.userInputPatterns == null;
 		this.userInputPatterns = new Pattern[userInputPatterns.length];

--- a/src/main/java/ch/njol/skript/effects/mirre/package-info.java
+++ b/src/main/java/ch/njol/skript/effects/mirre/package-info.java
@@ -1,0 +1,27 @@
+/*
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * 
+ * Copyright 2011-2013 Peter Güttinger
+ * 
+ */
+
+/**
+ * @author Peter Güttinger
+ *
+ */
+@org.eclipse.jdt.annotation.NonNullByDefault
+package ch.njol.skript.effects.mirre;

--- a/src/main/java/ch/njol/skript/entity/RabbitData.java
+++ b/src/main/java/ch/njol/skript/entity/RabbitData.java
@@ -21,10 +21,6 @@
 
 package ch.njol.skript.entity;
 
-import java.util.HashMap;
-
-import javax.annotation.Nullable;
-
 import org.bukkit.entity.Rabbit;
 
 import ch.njol.skript.Skript;

--- a/src/main/java/ch/njol/skript/entity/SheepData.java
+++ b/src/main/java/ch/njol/skript/entity/SheepData.java
@@ -144,6 +144,7 @@ public class SheepData extends EntityData<Sheep> {
 //		} else {
 //			return "" + sheared;
 //		}
+	@SuppressWarnings("null")
 	@Override
 	protected boolean deserialize(final String s) {
 		final String[] split = s.split("\\|");

--- a/src/main/java/ch/njol/skript/localization/Language.java
+++ b/src/main/java/ch/njol/skript/localization/Language.java
@@ -228,6 +228,7 @@ public class Language {
 		return true;
 	}
 	
+	@SuppressWarnings("resource") // closed in line 277.
 	private static boolean load(final SkriptAddon addon, final String name) {
 		if (addon.getLanguageFileDirectory() == null)
 			return false;

--- a/src/main/java/ch/njol/skript/mirre/FilterPrintStream.java
+++ b/src/main/java/ch/njol/skript/mirre/FilterPrintStream.java
@@ -3,7 +3,6 @@ package ch.njol.skript.mirre;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import java.util.logging.Filter;
 
 import ch.njol.skript.command.Commands;
 
@@ -23,7 +22,7 @@ public class FilterPrintStream extends PrintStream {
 	}
 	
 	@Override
-	public synchronized void println(String string){
+	public synchronized void println(@SuppressWarnings("null") String string){
 		if(Commands.suppressUnknownCommandMessage && string.contains("Unknown command. Type")){
 			Commands.suppressUnknownCommandMessage = false;
 			return;

--- a/src/main/java/ch/njol/skript/mirre/package-info.java
+++ b/src/main/java/ch/njol/skript/mirre/package-info.java
@@ -1,0 +1,27 @@
+/*
+ *   This file is part of Skript.
+ *
+ *  Skript is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Skript is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Skript.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * 
+ * Copyright 2011-2013 Peter Güttinger
+ * 
+ */
+
+/**
+ * @author Peter Güttinger
+ *
+ */
+@org.eclipse.jdt.annotation.NonNullByDefault
+package ch.njol.skript.mirre;


### PR DESCRIPTION
- Test package marked as "test source" (.classpath)
- Removed findbugs from running every build, it slows down a lot. If we need it, we can run it manually. (.project)
- Replaced some Njol github page references, the Njol's repo is now read-only. (pom.xml)
- The update site seems to be down. I added null check to avoid NPE in startup. (Skript.java)
- Added some @SuppressWarnings("null")'s to make code compilable
- Added NonNullByDefault as package-info java to mirreski related packages.
- Removed unused imports from some files.
- Patpeter's SQLibrary repo is down, downgraded version to 4.0 (this version is from Njol's repo)
- Updated bukkit version from 1.8.7 to 1.8.8.